### PR TITLE
Remove fallocate pre-allocation; log write progress every 10 GiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,12 +272,6 @@ rule_lifetime: ~          # Rule lifetime in seconds; null = permanent
 # Default: 512MiB. Larger values provide greater data variety across files.
 # buffer_reuse_ring_size: 512MiB
 
-# Disable fallocate() pre-allocation when placing files on the RSE.
-# fallocate is enabled by default and tells the OS to reserve disk space before writing,
-# reducing fragmentation and avoiding mid-write ENOSPC on most filesystems.
-# Disable on CephFS (and similar distributed filesystems) where fallocate() fills the
-# allocated space with zeroes instead of merely reserving it, causing unnecessary I/O.
-# fallocate: true
 ```
 
 Any YAML value can be overridden on the command line — see
@@ -566,7 +560,7 @@ All tests run in under ten seconds. No network access or RSE mount is required.
 ```
 usage: dataset-generator [--config PATH] [--dry-run] [--threads N]
                          [--log-level LEVEL] [--state-file PATH] [--run-id ID]
-                         [--check-auth] [--no-fallocate]
+                         [--check-auth]
                          [--create-only | --register-only | --cleanup]
                          [config overrides ...]
 
@@ -610,9 +604,6 @@ Config overrides (all settable in YAML; CLI wins):
                          Ring buffer size for buffer-reuse mode (default: 512MiB).
                          Same unit syntax as --file-size-bytes. Must be >= 128 MiB.
                          Memory footprint per worker process ≈ ring_size + 128 MiB.
-  --no-fallocate         Disable fallocate() pre-allocation when placing files on the RSE.
-                         Recommended on CephFS where fallocate() writes zeros instead of
-                         reserving space. Enabled by default on supporting filesystems.
   --registry-file PATH   Global registry JSON path (default: ~/.rucio-ds-generator/registry.json;
                          set to "" to disable)
   --rucio-host           Rucio server URL

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -118,13 +118,5 @@ rule_lifetime: ~
 # Examples: 512MiB (default), 1GiB, 2GiB
 # buffer_reuse_ring_size: 512MiB
 
-# posix_fallocate pre-allocation.  Default: true (enabled).
-# Disable on CephFS: on CephFS fallocate writes zeros to disk rather than
-# simply reserving space, making it as slow as a regular write with no
-# benefit.  On ext4/XFS fallocate is near-instant and eliminates
-# extent-allocation overhead during sequential writes.
-# fallocate: true
-# fallocate: false  # use this on CephFS
-
 # Logging level: DEBUG, INFO, WARNING, ERROR
 log_level: "INFO"

--- a/src/dataset_generator/__main__.py
+++ b/src/dataset_generator/__main__.py
@@ -220,15 +220,6 @@ def _build_parser():
         ),
     )
     ovr.add_argument(
-        "--no-fallocate", dest="fallocate", action="store_false", default=None,
-        help=(
-            "Disable posix_fallocate pre-allocation. "
-            "Recommended on CephFS where fallocate may write zeros to disk "
-            "rather than simply reserving space, making it as slow as a "
-            "regular write with none of the benefit. Default: enabled."
-        ),
-    )
-    ovr.add_argument(
         "--buffer-reuse-ring-size", dest="buffer_reuse_ring_size", metavar="SIZE",
         help=(
             "Ring buffer size for buffer-reuse mode. "

--- a/src/dataset_generator/config.py
+++ b/src/dataset_generator/config.py
@@ -157,7 +157,6 @@ class Config(object):
         "registry_file": None,   # None → DEFAULT_REGISTRY_FILE; "" → disabled
         "generation_mode": "csprng",        # FileWriter back-end; see writers.py
         "buffer_reuse_ring_size": "512MiB", # ring buffer size for buffer-reuse mode
-        "fallocate": True,                  # posix_fallocate pre-allocation (disable on CephFS)
     }
 
     def __init__(
@@ -193,7 +192,6 @@ class Config(object):
         registry_file=None,     # type: Optional[str]  registry path; None = default; "" = disabled
         generation_mode="csprng",          # type: str  FileWriter back-end key; see writers.py
         buffer_reuse_ring_size="512MiB",   # type: object  Ring size for buffer-reuse mode
-        fallocate=True,                    # type: bool  posix_fallocate pre-allocation; disable on CephFS
     ):
         self.scope = scope
         self.rse = rse
@@ -231,7 +229,6 @@ class Config(object):
         self.buffer_reuse_ring_size = _parse_size(
             buffer_reuse_ring_size if buffer_reuse_ring_size is not None else "512MiB"
         )
-        self.fallocate = bool(fallocate) if fallocate is not None else True
 
     # ------------------------------------------------------------------
     # Computed properties
@@ -469,7 +466,6 @@ class Config(object):
             registry_file=get("registry_file"),
             generation_mode=get("generation_mode"),
             buffer_reuse_ring_size=get("buffer_reuse_ring_size"),
-            fallocate=get("fallocate"),
         )
 
     # ------------------------------------------------------------------

--- a/src/dataset_generator/writers.py
+++ b/src/dataset_generator/writers.py
@@ -24,8 +24,7 @@ csprng (default)
     Streaming pseudo-random data via the fastest available stdlib generator
     (``random.randbytes`` on Python 3.9+, ``os.urandom`` on 3.6–3.8).
     Each chunk is independently generated and written through a raw OS file
-    descriptor.  ``posix_fallocate`` pre-allocates the file extent where
-    supported.
+    descriptor.
 
 buffer-reuse
     Pre-fills a fixed-size ring buffer with random data once at construction.
@@ -55,6 +54,11 @@ log = logging.getLogger(__name__)
 # (4 threads × 128 MiB = 512 MiB, 8 threads × 128 MiB = 1 GiB).
 CHUNK_SIZE = 128 * 1024 * 1024  # 128 MiB
 
+# Emit a write-progress INFO log line every this many bytes written.
+# At 10 GiB the interval is infrequent enough to avoid log noise for typical
+# file sizes (1–10 GiB) while still confirming progress on very large files.
+_PROGRESS_INTERVAL = 10 * 1024 * 1024 * 1024  # 10 GiB
+
 # Fastest available bulk-random-bytes generator.
 #
 # Python 3.9+  random.randbytes — MT19937 PRNG running entirely in userspace;
@@ -71,11 +75,6 @@ if sys.version_info >= (3, 9):
 else:
     _randbytes = os.urandom
     _RAND_METHOD = "os.urandom (CSPRNG, Python {}.{})".format(*sys.version_info[:2])
-
-# posix_fallocate pre-allocates the full file extent on disk before any data
-# is written, eliminating extent-allocation overhead during sequential writes.
-# Available on Linux/macOS; absent on Windows and some exotic filesystems.
-_HAS_FALLOCATE = hasattr(os, "posix_fallocate")
 
 
 def _fmt_size(n):
@@ -165,49 +164,23 @@ class CsprngFileWriter(FileWriter):
 
     Uses the fastest available stdlib PRNG (``random.randbytes`` on Python
     3.9+, ``os.urandom`` on 3.6–3.8).  Writes via a raw OS file descriptor
-    to avoid the ``BufferedWriter`` memcpy overhead.  ``os.posix_fallocate``
-    pre-allocates the file extent where supported.
+    to avoid the ``BufferedWriter`` memcpy overhead.
 
-    Thread-safe: all instance state is immutable after construction.
-
-    Parameters
-    ----------
-    use_fallocate:
-        Enable ``posix_fallocate`` pre-allocation.  Set to ``False`` on
-        CephFS, where fallocate may write zeros instead of reserving space
-        (making it as slow as a regular write with no benefit).  The flag
-        is silently forced to ``False`` on platforms without the syscall.
+    Thread-safe: no mutable instance state after construction.
     """
-
-    def __init__(self, use_fallocate=True):
-        # type: (bool) -> None
-        # True only if the OS supports fallocate AND the caller has enabled it.
-        self._use_fallocate = use_fallocate and _HAS_FALLOCATE
-
-    @classmethod
-    def from_config(cls, config):
-        # type: (Any) -> CsprngFileWriter
-        use_fallocate = getattr(config, "fallocate", True) if config is not None else True
-        return cls(use_fallocate=use_fallocate)
 
     @property
     def description(self):
         # type: () -> str
-        return "csprng | {} | chunk: {} MiB | fallocate: {}".format(
+        return "csprng | {} | chunk: {} MiB".format(
             _RAND_METHOD,
             CHUNK_SIZE // (1024 * 1024),
-            "yes" if self._use_fallocate else "no",
         )
 
     def write_file(self, path, size_bytes):
         # type: (str, int) -> tuple
         tname = threading.current_thread().name
         log.debug("[%s] csprng write_file: path=%s size=%d", tname, path, size_bytes)
-
-        # Log at INFO for large files (≥ 1 GiB); emit progress every 10%.
-        _GIB = 1024 * 1024 * 1024
-        progress_interval = size_bytes // 10 if size_bytes >= _GIB else 0
-        next_progress = progress_interval
 
         log.info("[%s] Writing %s (%d bytes) csprng → %s",
                  tname, _fmt_size(size_bytes), size_bytes, path)
@@ -216,19 +189,10 @@ class CsprngFileWriter(FileWriter):
         bytes_written = 0
         remaining = size_bytes
         chunk_num = 0
+        next_progress = _PROGRESS_INTERVAL
 
         fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o666)
         try:
-            # Pre-allocate full extent; silently ignored if unsupported.
-            # NOTE: posix_fallocate extends the file to size_bytes immediately,
-            # so 'ls -la' will show the final file size before data is written.
-            if self._use_fallocate:
-                try:
-                    os.posix_fallocate(fd, 0, size_bytes)
-                    log.debug("[%s] fallocate: ok (%d bytes)", tname, size_bytes)
-                except OSError as exc:
-                    log.debug("[%s] fallocate: skipped (%s)", tname, exc)
-
             while remaining > 0:
                 chunk_num += 1
                 chunk = min(CHUNK_SIZE, remaining)
@@ -244,11 +208,10 @@ class CsprngFileWriter(FileWriter):
                 remaining -= chunk
                 log.debug("[%s] chunk %d: wrote %d bytes, checksum=%08x, remaining=%d",
                           tname, chunk_num, chunk, checksum, remaining)
-                if progress_interval and bytes_written >= next_progress:
-                    pct = 100 * bytes_written // size_bytes
-                    log.info("[%s] Write progress: %d%% (%s / %s)",
-                             tname, pct, _fmt_size(bytes_written), _fmt_size(size_bytes))
-                    next_progress += progress_interval
+                if bytes_written >= next_progress:
+                    log.info("[%s] Write progress: %s / %s",
+                             tname, _fmt_size(bytes_written), _fmt_size(size_bytes))
+                    next_progress += _PROGRESS_INTERVAL
         finally:
             os.close(fd)
             log.debug("[%s] fd closed: %s", tname, path)
@@ -319,14 +282,10 @@ class BufferReuseFileWriter(FileWriter):
     ring_size:
         Size of the random ring in bytes.  Must be >= ``CHUNK_SIZE``
         (128 MiB).  Larger values provide greater data variety across chunks.
-    use_fallocate:
-        Enable ``posix_fallocate`` pre-allocation.  Set to ``False`` on
-        CephFS, where fallocate may write zeros instead of reserving space.
-        Silently forced to ``False`` on platforms without the syscall.
     """
 
-    def __init__(self, ring_size=_DEFAULT_RING_SIZE, use_fallocate=True):
-        # type: (int, bool) -> None
+    def __init__(self, ring_size=_DEFAULT_RING_SIZE):
+        # type: (int) -> None
         if ring_size < _MIN_RING_SIZE:
             raise ValueError(
                 "buffer_reuse_ring_size ({} bytes) must be >= CHUNK_SIZE "
@@ -335,7 +294,6 @@ class BufferReuseFileWriter(FileWriter):
                 )
             )
         self._ring_size = ring_size
-        self._use_fallocate = use_fallocate and _HAS_FALLOCATE
 
         # Fill ring with random data, then extend by CHUNK_SIZE bytes
         # (duplicate the ring's start) so every chunk access is contiguous.
@@ -360,17 +318,15 @@ class BufferReuseFileWriter(FileWriter):
             if config is not None
             else _DEFAULT_RING_SIZE
         )
-        use_fallocate = getattr(config, "fallocate", True) if config is not None else True
-        return cls(ring_size=ring_size, use_fallocate=use_fallocate)
+        return cls(ring_size=ring_size)
 
     @property
     def description(self):
         # type: () -> str
         return (
-            "buffer-reuse | ring: {} MiB | chunk: {} MiB | fallocate: {}".format(
+            "buffer-reuse | ring: {} MiB | chunk: {} MiB".format(
                 self._ring_size // (1024 * 1024),
                 CHUNK_SIZE // (1024 * 1024),
-                "yes" if self._use_fallocate else "no",
             )
         )
 
@@ -380,11 +336,6 @@ class BufferReuseFileWriter(FileWriter):
         log.debug("[%s] buffer-reuse write_file: path=%s size=%d ring=%d",
                   tname, path, size_bytes, self._ring_size)
 
-        # Log at INFO for large files (≥ 1 GiB); emit progress every 10%.
-        _GIB = 1024 * 1024 * 1024
-        progress_interval = size_bytes // 10 if size_bytes >= _GIB else 0
-        next_progress = progress_interval
-
         log.info("[%s] Writing %s (%d bytes) buffer-reuse → %s",
                  tname, _fmt_size(size_bytes), size_bytes, path)
 
@@ -393,16 +344,10 @@ class BufferReuseFileWriter(FileWriter):
         remaining = size_bytes
         extended = self._extended  # local ref avoids repeated attr lookup
         chunk_num = 0
+        next_progress = _PROGRESS_INTERVAL
 
         fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o666)
         try:
-            if self._use_fallocate:
-                try:
-                    os.posix_fallocate(fd, 0, size_bytes)
-                    log.debug("[%s] fallocate: ok (%d bytes)", tname, size_bytes)
-                except OSError as exc:
-                    log.debug("[%s] fallocate: skipped (%s)", tname, exc)
-
             while remaining > 0:
                 chunk_num += 1
                 chunk = min(CHUNK_SIZE, remaining)
@@ -423,11 +368,10 @@ class BufferReuseFileWriter(FileWriter):
                 remaining -= chunk
                 log.debug("[%s] chunk %d: wrote %d bytes, checksum=%08x, remaining=%d",
                           tname, chunk_num, chunk, checksum, remaining)
-                if progress_interval and bytes_written >= next_progress:
-                    pct = 100 * bytes_written // size_bytes
-                    log.info("[%s] Write progress: %d%% (%s / %s)",
-                             tname, pct, _fmt_size(bytes_written), _fmt_size(size_bytes))
-                    next_progress += progress_interval
+                if bytes_written >= next_progress:
+                    log.info("[%s] Write progress: %s / %s",
+                             tname, _fmt_size(bytes_written), _fmt_size(size_bytes))
+                    next_progress += _PROGRESS_INTERVAL
         finally:
             os.close(fd)
             log.debug("[%s] fd closed: %s", tname, path)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -14,7 +14,6 @@ from dataset_generator.writers import (
     CsprngFileWriter,
     FileWriter,
     _DEFAULT_RING_SIZE,
-    _HAS_FALLOCATE,
     _MIN_RING_SIZE,
     _RAND_METHOD,
     _WRITER_REGISTRY,
@@ -75,10 +74,6 @@ class TestCsprngFileWriter:
 
     def test_description_contains_chunk_size(self, writer):
         assert "128" in writer.description   # CHUNK_SIZE = 128 MiB
-
-    def test_description_contains_fallocate_status(self, writer):
-        expected = "yes" if _HAS_FALLOCATE else "no"
-        assert "fallocate: {}".format(expected) in writer.description
 
     def test_description_contains_rand_method(self, writer):
         # _RAND_METHOD contains "MT19937" or "CSPRNG" depending on Python version
@@ -141,11 +136,8 @@ class TestCsprngFileWriter:
         assert 0 <= checksum <= 0xFFFFFFFF
 
     def test_thread_safe_no_shared_mutable_state(self, writer):
-        """CsprngFileWriter has only immutable instance state — safe to share across threads."""
-        # _use_fallocate is set once at construction and never mutated.
-        assert isinstance(writer._use_fallocate, bool)
-        # No other instance attributes should exist.
-        assert set(writer.__dict__.keys()) == {"_use_fallocate"}
+        """CsprngFileWriter has no mutable instance state — safe to share across threads."""
+        assert writer.__dict__ == {}
 
 
 # ---------------------------------------------------------------------------
@@ -177,10 +169,6 @@ class TestBufferReuseFileWriter:
 
     def test_description_contains_chunk_size(self, writer):
         assert "128" in writer.description
-
-    def test_description_contains_fallocate_status(self, writer):
-        expected = "yes" if _HAS_FALLOCATE else "no"
-        assert "fallocate: {}".format(expected) in writer.description
 
     def test_write_correct_size(self, tmp_path, writer):
         path = str(tmp_path / "f")
@@ -361,6 +349,3 @@ class TestModuleConstants:
     def test_rand_method_is_string(self):
         assert isinstance(_RAND_METHOD, str)
         assert len(_RAND_METHOD) > 0
-
-    def test_has_fallocate_is_bool(self):
-        assert isinstance(_HAS_FALLOCATE, bool)


### PR DESCRIPTION
## Summary

- **Remove `posix_fallocate` pre-allocation** from both `CsprngFileWriter` and `BufferReuseFileWriter`. On CephFS (the deployment target) `fallocate()` writes zeros to disk rather than simply reserving space, making it as slow as a full write with no benefit. Removed entirely rather than kept as a config option — the complexity is not justified.
- **Write progress logging changed from every 10% → every 10 GiB** (`_PROGRESS_INTERVAL` constant). The previous 10% interval was noisy for typical 1–10 GiB files (10 log lines per file); the new fixed interval fires only for very large files.

### Files changed
| File | Change |
|------|--------|
| `writers.py` | Remove `_HAS_FALLOCATE`, `use_fallocate` params, `posix_fallocate` blocks; replace progress interval logic with `_PROGRESS_INTERVAL = 10 GiB` |
| `config.py` | Remove `fallocate` field and default |
| `__main__.py` | Remove `--no-fallocate` CLI flag |
| `config.example.yaml` | Remove fallocate section |
| `README.md` | Remove fallocate from YAML config and CLI reference |
| `tests/test_writers.py` | Remove 3 fallocate tests; update mutable-state assertion for empty `__dict__` |

## Test plan

- [x] `pytest` — 271 tests, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)