### PR TITLE
feat: write XrdCks adler32 xattr to placed RSE files

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -118,5 +118,12 @@ rule_lifetime: ~
 # Examples: 512MiB (default), 1GiB, 2GiB
 # buffer_reuse_ring_size: 512MiB
 
+# Write XrdCks adler32 extended attribute (user.XrdCks.adler32) to each placed
+# file after placement.  XRootD reads this attribute for checksum validation,
+# avoiding a full re-read of the file.  The already-computed adler32 is reused
+# (no extra I/O).  Silently skipped on platforms without os.setxattr (macOS,
+# Windows).  Set to false or pass --no-xattr to disable.
+# xattr: true
+
 # Logging level: DEBUG, INFO, WARNING, ERROR
 log_level: "INFO"

--- a/src/dataset_generator/__main__.py
+++ b/src/dataset_generator/__main__.py
@@ -235,6 +235,14 @@ def _build_parser():
             "Set to empty string to disable registry recording.".format(DEFAULT_REGISTRY_FILE)
         ),
     )
+    ovr.add_argument(
+        "--no-xattr", dest="xattr", action="store_false", default=None,
+        help=(
+            "Disable writing the XrdCks adler32 extended attribute "
+            "(user.XrdCks.adler32) to placed files. "
+            "Default: xattr writing is enabled when supported by the OS."
+        ),
+    )
 
     return parser
 

--- a/src/dataset_generator/config.py
+++ b/src/dataset_generator/config.py
@@ -157,6 +157,7 @@ class Config(object):
         "registry_file": None,   # None → DEFAULT_REGISTRY_FILE; "" → disabled
         "generation_mode": "csprng",        # FileWriter back-end; see writers.py
         "buffer_reuse_ring_size": "512MiB", # ring buffer size for buffer-reuse mode
+        "xattr": True,                      # write XrdCks adler32 xattr after placement
     }
 
     def __init__(
@@ -192,6 +193,7 @@ class Config(object):
         registry_file=None,     # type: Optional[str]  registry path; None = default; "" = disabled
         generation_mode="csprng",          # type: str  FileWriter back-end key; see writers.py
         buffer_reuse_ring_size="512MiB",   # type: object  Ring size for buffer-reuse mode
+        xattr=True,                        # type: bool  Write XrdCks adler32 xattr after placement
     ):
         self.scope = scope
         self.rse = rse
@@ -229,6 +231,7 @@ class Config(object):
         self.buffer_reuse_ring_size = _parse_size(
             buffer_reuse_ring_size if buffer_reuse_ring_size is not None else "512MiB"
         )
+        self.xattr = bool(xattr) if xattr is not None else True
 
     # ------------------------------------------------------------------
     # Computed properties
@@ -466,6 +469,7 @@ class Config(object):
             registry_file=get("registry_file"),
             generation_mode=get("generation_mode"),
             buffer_reuse_ring_size=get("buffer_reuse_ring_size"),
+            xattr=get("xattr"),
         )
 
     # ------------------------------------------------------------------

--- a/src/dataset_generator/generator.py
+++ b/src/dataset_generator/generator.py
@@ -59,7 +59,9 @@ import logging.handlers
 import multiprocessing
 import os
 import random
+import struct
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 
@@ -69,6 +71,67 @@ from .state import FileStatus, StateFile
 from .writers import FileWriter, get_file_writer
 
 log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# XrdCks extended-attribute support
+# ---------------------------------------------------------------------------
+
+#: Extended-attribute key used by XRootD for adler32 checksums.
+#: XrdCksXAttr::Name() returns "XrdCks.<algname>"; the Linux setxattr layer
+#: prepends "user." (XrdSysFAttrLnx.icc, AttrName macro).
+_XRDCKS_XATTR_NAME = "user.XrdCks.adler32"
+
+#: True when the OS supports os.setxattr (Linux kernel 2.6+, Python 3.3+).
+#: On macOS, Windows, or older kernels this is False and xattr writes are
+#: silently skipped regardless of the ``xattr`` config flag.
+_HAS_SETXATTR = hasattr(os, "setxattr")
+
+
+def _set_xrdcks_xattr(path, adler32_int):
+    # type: (str, int) -> None
+    """
+    Write the XRootD ``user.XrdCks.adler32`` extended attribute to *path*.
+
+    XRootD reads this attribute via ``XrdCksXAttr`` and uses it for
+    checksum validation without re-reading the file.  When the stored
+    ``fmTime`` (file-modification time) matches the file's current mtime
+    on disk XRootD trusts the stored checksum; a mismatch causes it to
+    re-checksum the file automatically.
+
+    Blob layout (96 bytes total — ``XrdCksData`` struct)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ============  =====  =========  ==============  =====================
+    Field         Bytes  C type     Endian          Content
+    ============  =====  =========  ==============  =====================
+    Name          16     char[16]   n/a             "adler32\\0" + padding
+    fmTime        8      int64      big-endian      file mtime (seconds)
+    csTime        4      int32      big-endian      checksum time (secs)
+    Rsvd1         2      int16      host            reserved (0)
+    Rsvd2         1      uint8      host            reserved (0)
+    Length        1      uint8      host            value length in bytes
+    Value         64     uint8[64]  host (first 4)  adler32 in first 4 B
+    ============  =====  =========  ==============  =====================
+
+    Parameters
+    ----------
+    path:
+        Absolute path to the file on the RSE (after placement/rename).
+    adler32_int:
+        Adler32 checksum of the file as an unsigned 32-bit integer
+        (i.e. ``zlib.adler32(data, 1) & 0xFFFFFFFF``).
+    """
+    now = int(time.time())
+    fm_time = int(os.stat(path).st_mtime)
+    # Name field: "adler32\0" padded to 16 bytes.
+    name_bytes = b"adler32\x00" + b"\x00" * 8  # 16 bytes
+    # fmTime and csTime: big-endian (network byte order) signed integers.
+    times = struct.pack(">qi", fm_time, now)    # 8 + 4 = 12 bytes
+    # Rsvd1 (int16), Rsvd2 (uint8), Length (uint8 = 4): host byte order.
+    meta = struct.pack("=hBB", 0, 0, 4)         # 4 bytes
+    # Value: adler32 in first 4 bytes (host byte order), rest zero-padded.
+    value = struct.pack("=I", adler32_int) + b"\x00" * 60  # 64 bytes
+    blob = name_bytes + times + meta + value    # 16+12+4+64 = 96 bytes
+    os.setxattr(path, _XRDCKS_XATTR_NAME, blob)
 
 
 # ---------------------------------------------------------------------------
@@ -563,6 +626,14 @@ def run_generation(config, state, rucio_manager, new_count=None):
                     bytes=bytes_written2,
                     adler32=checksum_hex2,
                 )
+                if config.xattr and _HAS_SETXATTR:
+                    try:
+                        _set_xrdcks_xattr(local_pfn2, int(checksum_hex2, 16))
+                        log.debug("[file-%06d] XrdCks xattr set: %s",
+                                  idx2, local_pfn2)
+                    except OSError as exc:
+                        log.warning("[file-%06d] XrdCks xattr failed: %s",
+                                    idx2, exc)
                 results.append({
                     "key": key2,
                     "lfn": lfn2,
@@ -616,6 +687,9 @@ def run_generation(config, state, rucio_manager, new_count=None):
                             bytes=bytes_written,
                             adler32=checksum_hex,
                         )
+                        if config.xattr and _HAS_SETXATTR:
+                            log.info("[DRY-RUN] Would set XrdCks xattr: %s",
+                                     local_pfn)
                         results.append({
                             "key": key,
                             "lfn": lfn,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -628,3 +628,120 @@ class TestRunGeneration:
         staging_files = os.listdir(config.staging_dir)
         tmp_files = [f for f in staging_files if ".tmp." in f]
         assert tmp_files == [], "orphaned staging files: {}".format(tmp_files)
+
+
+# ---------------------------------------------------------------------------
+# _set_xrdcks_xattr
+# ---------------------------------------------------------------------------
+
+import struct as _struct
+import zlib as _zlib
+from dataset_generator.generator import (
+    _set_xrdcks_xattr,
+    _HAS_SETXATTR,
+    _XRDCKS_XATTR_NAME,
+)
+
+
+@pytest.mark.skipif(not _HAS_SETXATTR, reason="os.setxattr not available on this platform")
+class TestSetXrdcksXattr:
+    def _read_blob(self, path):
+        return os.getxattr(path, _XRDCKS_XATTR_NAME)
+
+    def test_blob_is_96_bytes(self, tmp_path):
+        path = str(tmp_path / "f")
+        open(path, "wb").close()
+        _set_xrdcks_xattr(path, 0xDEADBEEF)
+        assert len(self._read_blob(path)) == 96
+
+    def test_name_field_is_adler32(self, tmp_path):
+        path = str(tmp_path / "f")
+        open(path, "wb").close()
+        _set_xrdcks_xattr(path, 0x12345678)
+        blob = self._read_blob(path)
+        # First 8 bytes are "adler32\0"; next 8 are zero padding.
+        assert blob[:8] == b"adler32\x00"
+        assert blob[8:16] == b"\x00" * 8
+
+    def test_adler32_value_stored_host_order(self, tmp_path):
+        path = str(tmp_path / "f")
+        open(path, "wb").close()
+        adler = 0xCAFEBABE
+        _set_xrdcks_xattr(path, adler)
+        blob = self._read_blob(path)
+        # Value field starts at offset 32; first 4 bytes, host byte order.
+        stored = _struct.unpack("=I", blob[32:36])[0]
+        assert stored == adler
+
+    def test_length_field_is_4(self, tmp_path):
+        path = str(tmp_path / "f")
+        open(path, "wb").close()
+        _set_xrdcks_xattr(path, 1)
+        blob = self._read_blob(path)
+        # Length is the 4th byte of the meta field at offset 28 (after Rsvd1+Rsvd2).
+        # Layout: Rsvd1(2) + Rsvd2(1) + Length(1) at bytes 28-31.
+        length = _struct.unpack("=B", blob[31:32])[0]
+        assert length == 4
+
+    def test_fmtime_big_endian(self, tmp_path):
+        path = str(tmp_path / "f")
+        open(path, "wb").close()
+        _set_xrdcks_xattr(path, 1)
+        blob = self._read_blob(path)
+        fm_time = _struct.unpack(">q", blob[16:24])[0]
+        # fmTime must match the file's mtime (within a 2-second window).
+        assert abs(fm_time - int(os.stat(path).st_mtime)) <= 2
+
+    def test_value_tail_is_zero_padded(self, tmp_path):
+        path = str(tmp_path / "f")
+        open(path, "wb").close()
+        _set_xrdcks_xattr(path, 0xDEADBEEF)
+        blob = self._read_blob(path)
+        # Bytes 36-96 (Value[4:64]) must all be zero.
+        assert blob[36:] == b"\x00" * 60
+
+    def test_xattr_key_name(self, tmp_path):
+        assert _XRDCKS_XATTR_NAME == "user.XrdCks.adler32"
+
+    def test_oserror_propagates(self, tmp_path):
+        """_set_xrdcks_xattr raises OSError when the path does not exist."""
+        with pytest.raises(OSError):
+            _set_xrdcks_xattr(str(tmp_path / "nonexistent"), 1)
+
+
+@pytest.mark.skipif(not _HAS_SETXATTR, reason="os.setxattr not available on this platform")
+class TestXattrIntegration:
+    """Verify xattr is set (or skipped) on files placed by run_generation."""
+
+    def test_xattr_written_when_enabled(self, config, state, mock_rucio):
+        """With config.xattr=True, every placed file gets the xattr."""
+        config.xattr = True
+        run_generation(config, state, mock_rucio)
+        created = state.get_files_by_status(FileStatus.CREATED)
+        assert len(created) == config.num_files
+        for entry in created:
+            blob = os.getxattr(entry["pfn"], _XRDCKS_XATTR_NAME)
+            assert len(blob) == 96
+            # Value field: stored adler32 must match the state entry.
+            stored = _struct.unpack("=I", blob[32:36])[0]
+            assert stored == int(entry["adler32"], 16)
+
+    def test_xattr_not_written_when_disabled(self, config, state, mock_rucio):
+        """With config.xattr=False, no xattr is set on placed files."""
+        config.xattr = False
+        run_generation(config, state, mock_rucio)
+        created = state.get_files_by_status(FileStatus.CREATED)
+        assert len(created) == config.num_files
+        for entry in created:
+            with pytest.raises(OSError):
+                os.getxattr(entry["pfn"], _XRDCKS_XATTR_NAME)
+
+    def test_xattr_oserror_does_not_fail_generation(self, config, state, mock_rucio):
+        """An OSError from setxattr is logged as WARNING but does not abort placement."""
+        config.xattr = True
+        with patch("dataset_generator.generator._set_xrdcks_xattr",
+                   side_effect=OSError("xattr quota exceeded")):
+            results = run_generation(config, state, mock_rucio)
+        assert len(results) == config.num_files
+        created = state.get_files_by_status(FileStatus.CREATED)
+        assert len(created) == config.num_files


### PR DESCRIPTION
## Summary

- After each file is placed on the RSE, write the `user.XrdCks.adler32` extended attribute using the already-computed adler32 checksum — no extra I/O
- XRootD reads this attribute for checksum validation; a stored `fmTime` matching the file's mtime avoids a full re-read on first access
- Blob follows the 96-byte `XrdCksData` layout: `Name[16]` = `"adler32\0"+pad`, `fmTime`/`csTime` big-endian, `Length = 4`, adler32 value in first 4 bytes of `Value` (host byte order), rest zero-padded
- Enabled by default; disable with `xattr: false` in YAML or `--no-xattr` CLI flag
- Silently skipped on platforms without `os.setxattr` (macOS, Windows); `OSError` logged as WARNING without aborting placement

## Changes

| File | Change |
|------|--------|
| `generator.py` | `_XRDCKS_XATTR_NAME`, `_HAS_SETXATTR`, `_set_xrdcks_xattr()`, call in `_handle_placement_future` and dry-run path |
| `config.py` | `xattr` field (default `True`) in `_DEFAULTS`, `__init__`, `from_yaml_and_args` |
| `__main__.py` | `--no-xattr` CLI flag |
| `config.example.yaml` | Documents `xattr` option |
| `tests/test_generator.py` | `TestSetXrdcksXattr` (8 unit tests for blob structure) + `TestXattrIntegration` (3 integration tests) |

## Test plan

- [x] 282 tests passing locally (all platforms where `os.setxattr` is available)
- [x] `TestSetXrdcksXattr`: verifies blob size (96 bytes), Name field, adler32 stored in host byte order, Length=4, fmTime big-endian, zero-padded tail, key name, OSError propagation
- [x] `TestXattrIntegration`: xattr written when enabled, not written when disabled, OSError from setxattr does not abort generation
- [x] CI matrix: Rocky Linux 8/3.6, Rocky Linux 9/3.9, Ubuntu/3.11, Ubuntu/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)