### PR TITLE
feat: IEC/SI unit selection for file_size template variable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -24,7 +24,10 @@ rse_mount: "/mnt/rse/T2_US_EXAMPLE"
 #   {{ scope }}          Rucio scope
 #   {{ rse }}            Target RSE name
 #   {{ num_files }}      Number of files (integer)
-#   {{ file_size }}      Human-readable file size (e.g. 1GiB, 512MiB)
+#   {{ file_size }}      Human-readable file size using the selected unit system
+#                        (e.g. 1GiB or 1GB depending on size_label; see below)
+#   {{ file_size_iec }}  File size always in IEC binary units (e.g. 1GiB, 512MiB)
+#   {{ file_size_si }}   File size always in SI decimal units (e.g. 1GB, 536MB)
 #   {{ file_size_bytes}} Raw file size in bytes
 #   {{ dataset_prefix }} Dataset prefix string
 #
@@ -117,6 +120,15 @@ rule_lifetime: ~
 # IEC units (binary): KiB = 1024, MiB = 1024², GiB = 1024³
 # Examples: 512MiB (default), 1GiB, 2GiB
 # buffer_reuse_ring_size: 512MiB
+
+# Unit system used for the {{ file_size }} Jinja2 template variable in dataset
+# and file prefix names.
+#   iec (default): binary powers of 1024 — KiB, MiB, GiB, TiB, PiB
+#   si:            decimal powers of 1000 — KB,  MB,  GB,  TB,  PB
+# Note: {{ file_size_iec }} and {{ file_size_si }} are always available in
+# templates regardless of this setting, so you can mix both in a single name:
+#   dataset_name: "{{ dataset_prefix }}_{{ file_size_si }}_{{ date }}"
+# size_label: iec
 
 # Write XrdCks adler32 extended attribute (user.XrdCks.adler32) to each placed
 # file after placement.  XRootD reads this attribute for checksum validation,

--- a/src/dataset_generator/__main__.py
+++ b/src/dataset_generator/__main__.py
@@ -236,6 +236,17 @@ def _build_parser():
         ),
     )
     ovr.add_argument(
+        "--size-label", dest="size_label", choices=["iec", "si"], metavar="SYSTEM",
+        help=(
+            "Unit system for the {{ file_size }} template variable used in dataset "
+            "and file prefix names. "
+            "'iec' (default): binary powers of 1024 — KiB, MiB, GiB, TiB. "
+            "'si': decimal powers of 1000 — KB, MB, GB, TB. "
+            "Both {{ file_size_iec }} and {{ file_size_si }} are always available "
+            "in templates regardless of this setting."
+        ),
+    )
+    ovr.add_argument(
         "--no-xattr", dest="xattr", action="store_false", default=None,
         help=(
             "Disable writing the XrdCks adler32 extended attribute "

--- a/src/dataset_generator/config.py
+++ b/src/dataset_generator/config.py
@@ -25,20 +25,31 @@ import yaml
 from jinja2 import Template, TemplateError
 
 
-def _human_size(size_bytes):
-    # type: (int) -> str
+def _human_size(size_bytes, si=False):
+    # type: (int, bool) -> str
     """Return *size_bytes* as a compact human-readable string.
 
-    Examples: ``1B``, ``512KiB``, ``64MiB``, ``1GiB``, ``2TiB``.
+    When *si* is ``False`` (default, IEC): powers of 1024 with binary
+    suffixes — e.g. ``512B``, ``2KiB``, ``64MiB``, ``1GiB``, ``2TiB``.
+
+    When *si* is ``True`` (SI): powers of 1000 with decimal suffixes —
+    e.g. ``512B``, ``2KB``, ``64MB``, ``1GB``, ``2TB``.
+
     Values are always formatted as integers (no decimal point) so the
     result is safe to embed in Rucio DID names.
     """
+    if si:
+        divisor = 1000.0
+        units = ("B", "KB", "MB", "GB", "TB", "PB")
+    else:
+        divisor = 1024.0
+        units = ("B", "KiB", "MiB", "GiB", "TiB", "PiB")
     value = float(size_bytes)
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if value < 1024.0:
+    for unit in units[:-1]:
+        if value < divisor:
             return "{}{}".format(int(value), unit)
-        value /= 1024.0
-    return "{}PiB".format(int(value))
+        value /= divisor
+    return "{}{}".format(int(value), units[-1])
 
 
 # SI (decimal, powers of 1000): KB, MB, GB, TB, PB
@@ -158,6 +169,7 @@ class Config(object):
         "generation_mode": "csprng",        # FileWriter back-end; see writers.py
         "buffer_reuse_ring_size": "512MiB", # ring buffer size for buffer-reuse mode
         "xattr": True,                      # write XrdCks adler32 xattr after placement
+        "size_label": "iec",                # unit system for {{ file_size }} template: "iec" or "si"
     }
 
     def __init__(
@@ -194,6 +206,7 @@ class Config(object):
         generation_mode="csprng",          # type: str  FileWriter back-end key; see writers.py
         buffer_reuse_ring_size="512MiB",   # type: object  Ring size for buffer-reuse mode
         xattr=True,                        # type: bool  Write XrdCks adler32 xattr after placement
+        size_label="iec",                  # type: str   Unit system for {{ file_size }}: "iec" or "si"
     ):
         self.scope = scope
         self.rse = rse
@@ -232,6 +245,7 @@ class Config(object):
             buffer_reuse_ring_size if buffer_reuse_ring_size is not None else "512MiB"
         )
         self.xattr = bool(xattr) if xattr is not None else True
+        self.size_label = (size_label or "iec").lower()
 
     # ------------------------------------------------------------------
     # Computed properties
@@ -334,13 +348,25 @@ class Config(object):
         ``num_files``
             Number of files to generate (integer).
         ``file_size``
-            Human-readable file size (e.g. ``1GiB``, ``512MiB``).
+            Human-readable file size using the unit system selected by
+            ``size_label`` (default ``iec``).  E.g. ``1GiB`` (IEC) or
+            ``1GB`` (SI).
+        ``file_size_iec``
+            Human-readable file size always in IEC binary units
+            (KiB / MiB / GiB / TiB / PiB).  Available regardless of
+            the ``size_label`` setting.
+        ``file_size_si``
+            Human-readable file size always in SI decimal units
+            (KB / MB / GB / TB / PB).  Available regardless of the
+            ``size_label`` setting.
         ``file_size_bytes``
             Raw file size in bytes (integer).
         ``dataset_prefix``
             Dataset prefix string (useful in ``dataset_name`` templates).
         """
         now = datetime.now(timezone.utc)
+        _iec = _human_size(self.file_size_bytes, si=False)
+        _si  = _human_size(self.file_size_bytes, si=True)
         return {
             "date":            now.strftime("%Y%m%d"),
             "datetime":        now.strftime("%Y%m%d_%H%M%S"),
@@ -349,7 +375,9 @@ class Config(object):
             "scope":           self.scope,
             "rse":             self.rse,
             "num_files":       self.num_files,
-            "file_size":       _human_size(self.file_size_bytes),
+            "file_size":       _si if self.size_label == "si" else _iec,
+            "file_size_iec":   _iec,
+            "file_size_si":    _si,
             "file_size_bytes": self.file_size_bytes,
             "dataset_prefix":  self.dataset_prefix,
         }
@@ -470,6 +498,7 @@ class Config(object):
             generation_mode=get("generation_mode"),
             buffer_reuse_ring_size=get("buffer_reuse_ring_size"),
             xattr=get("xattr"),
+            size_label=get("size_label"),
         )
 
     # ------------------------------------------------------------------
@@ -484,6 +513,10 @@ class Config(object):
 
         Call this after construction and before starting any work.
         """
+        if self.size_label not in ("iec", "si"):
+            raise ConfigError(
+                "size_label must be 'iec' or 'si', got {!r}".format(self.size_label)
+            )
         if self.create_only and self.register_only:
             raise ConfigError("--create-only and --register-only are mutually exclusive")
         if self.cleanup and (self.create_only or self.register_only):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -528,6 +528,70 @@ class TestNamingTemplates:
         from dataset_generator.config import _human_size
         assert _human_size(1024 ** 4) == "1TiB"
 
+    # SI mode
+    def test_human_size_si_bytes(self):
+        from dataset_generator.config import _human_size
+        assert _human_size(512, si=True) == "512B"
+
+    def test_human_size_si_kb(self):
+        from dataset_generator.config import _human_size
+        assert _human_size(2000, si=True) == "2KB"
+
+    def test_human_size_si_mb(self):
+        from dataset_generator.config import _human_size
+        assert _human_size(1_000_000, si=True) == "1MB"
+
+    def test_human_size_si_gb(self):
+        from dataset_generator.config import _human_size
+        assert _human_size(1_000_000_000, si=True) == "1GB"
+
+    def test_human_size_si_tb(self):
+        from dataset_generator.config import _human_size
+        assert _human_size(1_000_000_000_000, si=True) == "1TB"
+
+    def test_human_size_si_gib_size_in_si(self):
+        """1 GiB expressed in SI rounds to 1 GB (1073741824 / 10^9 = 1.07...)."""
+        from dataset_generator.config import _human_size
+        assert _human_size(1024 ** 3, si=True) == "1GB"
+
+    # ------------------------------------------------------------------
+    # size_label config and template variables
+    # ------------------------------------------------------------------
+
+    def test_size_label_default_is_iec(self):
+        cfg = self._cfg()
+        assert cfg.size_label == "iec"
+
+    def test_file_size_template_default_is_iec(self):
+        cfg = self._cfg(file_prefix="f_{{ file_size }}", file_size_bytes=1024 ** 3)
+        assert cfg.file_prefix == "f_1GiB"
+
+    def test_file_size_template_si(self):
+        cfg = self._cfg(file_prefix="f_{{ file_size }}", file_size_bytes=1_000_000_000,
+                        size_label="si")
+        assert cfg.file_prefix == "f_1GB"
+
+    def test_file_size_iec_always_available(self):
+        """{{ file_size_iec }} is always IEC regardless of size_label."""
+        cfg = self._cfg(file_prefix="{{ file_size_iec }}", file_size_bytes=1024 ** 3,
+                        size_label="si")
+        assert cfg.file_prefix == "1GiB"
+
+    def test_file_size_si_always_available(self):
+        """{{ file_size_si }} is always SI regardless of size_label."""
+        cfg = self._cfg(file_prefix="{{ file_size_si }}", file_size_bytes=1_000_000_000,
+                        size_label="iec")
+        assert cfg.file_prefix == "1GB"
+
+    def test_size_label_case_insensitive(self):
+        cfg = self._cfg(size_label="SI")
+        assert cfg.size_label == "si"
+
+    def test_size_label_invalid_raises_on_validate(self):
+        cfg = self._cfg(size_label="binary")
+        with pytest.raises(ConfigError, match="size_label"):
+            cfg.validate()
+
     # ------------------------------------------------------------------
     # file_prefix cache
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `size_label` config setting (`"iec"` | `"si"`, default `"iec"`) that controls the unit system used by `{{ file_size }}` in Jinja2 dataset/file-prefix name templates
- IEC (default): powers of 1024 — KiB, MiB, GiB, TiB, PiB  
- SI: powers of 1000 — KB, MB, GB, TB, PB
- Two additional always-available template variables so templates can use either system regardless of the default:
  - `{{ file_size_iec }}` — always IEC binary (e.g. `1GiB`)
  - `{{ file_size_si }}` — always SI decimal (e.g. `1GB`)
- `--size-label {iec,si}` CLI flag added
- `size_label` validated in `Config.validate()`; unknown values raise `ConfigError`

## Changes

| File | Change |
|------|--------|
| `config.py` | `_human_size(si=False)` param; `size_label` in defaults/`__init__`/`from_yaml_and_args`/`validate`; `file_size_iec` + `file_size_si` in `_template_context` |
| `__main__.py` | `--size-label {iec,si}` CLI flag |
| `config.example.yaml` | Template variable table updated; `size_label` documented |
| `tests/test_config.py` | 13 new tests: SI `_human_size`, explicit template vars, label defaulting, case-normalisation, validation |

## Test plan

- [x] 295 tests passing locally
- [x] `_human_size(si=True)`: B, KB, MB, GB, TB; 1 GiB in SI rounds to 1 GB
- [x] `{{ file_size }}` follows `size_label`; IEC unchanged by default
- [x] `{{ file_size_iec }}` and `{{ file_size_si }}` independent of `size_label`
- [x] `size_label` is lowercased (case-insensitive); invalid value raises `ConfigError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)