### PR TITLE
fix: store XrdCks adler32 xattr Value field as big-endian

### DIFF
--- a/src/dataset_generator/generator.py
+++ b/src/dataset_generator/generator.py
@@ -109,7 +109,7 @@ def _set_xrdcks_xattr(path, adler32_int):
     Rsvd1         2      int16      host            reserved (0)
     Rsvd2         1      uint8      host            reserved (0)
     Length        1      uint8      host            value length in bytes
-    Value         64     uint8[64]  host (first 4)  adler32 in first 4 B
+    Value         64     uint8[64]  big-endian      adler32 in first 4 B
     ============  =====  =========  ==============  =====================
 
     Parameters
@@ -128,8 +128,10 @@ def _set_xrdcks_xattr(path, adler32_int):
     times = struct.pack(">qi", fm_time, now)    # 8 + 4 = 12 bytes
     # Rsvd1 (int16), Rsvd2 (uint8), Length (uint8 = 4): host byte order.
     meta = struct.pack("=hBB", 0, 0, 4)         # 4 bytes
-    # Value: adler32 in first 4 bytes (host byte order), rest zero-padded.
-    value = struct.pack("=I", adler32_int) + b"\x00" * 60  # 64 bytes
+    # Value: adler32 in first 4 bytes (big-endian), rest zero-padded.
+    # XRootD reads Value[0] as a big-endian uint32 (matching fmTime/csTime).
+    # Using host/LE order here causes a byte-reversed checksum mismatch.
+    value = struct.pack(">I", adler32_int) + b"\x00" * 60  # 64 bytes
     blob = name_bytes + times + meta + value    # 16+12+4+64 = 96 bytes
     os.setxattr(path, _XRDCKS_XATTR_NAME, blob)
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -871,14 +871,15 @@ class TestSetXrdcksXattr:
         assert blob[:8] == b"adler32\x00"
         assert blob[8:16] == b"\x00" * 8
 
-    def test_adler32_value_stored_host_order(self, tmp_path):
+    def test_adler32_value_stored_big_endian(self, tmp_path):
         path = str(tmp_path / "f")
         open(path, "wb").close()
         adler = 0xCAFEBABE
         _set_xrdcks_xattr(path, adler)
         blob = self._read_blob(path)
-        # Value field starts at offset 32; first 4 bytes, host byte order.
-        stored = _struct.unpack("=I", blob[32:36])[0]
+        # Value field starts at offset 32; first 4 bytes, big-endian.
+        # XRootD reads Value[0] as big-endian uint32 (same as fmTime/csTime).
+        stored = _struct.unpack(">I", blob[32:36])[0]
         assert stored == adler
 
     def test_length_field_is_4(self, tmp_path):
@@ -930,8 +931,8 @@ class TestXattrIntegration:
         for entry in created:
             blob = os.getxattr(entry["pfn"], _XRDCKS_XATTR_NAME)
             assert len(blob) == 96
-            # Value field: stored adler32 must match the state entry.
-            stored = _struct.unpack("=I", blob[32:36])[0]
+            # Value field: stored adler32 must match the state entry (big-endian).
+            stored = _struct.unpack(">I", blob[32:36])[0]
             assert stored == int(entry["adler32"], 16)
 
     def test_xattr_not_written_when_disabled(self, config, state, mock_rucio):


### PR DESCRIPTION
## Summary

- The `XrdCksData.Value[0]` field in `_set_xrdcks_xattr()` was packed with `struct.pack("=I", ...)` (host/native byte order = LE on x86)
- XRootD reads this field as big-endian, causing it to see a byte-reversed checksum — e.g. actual checksum `a9a61408` stored as bytes `08 14 a6 a9`, read back by XRootD as `0814a6a9`
- Fix: change to `struct.pack(">I", ...)` to match the byte order XRootD expects (consistent with `fmTime`/`csTime` which are already big-endian)

Closes #10

## Changes

- `src/dataset_generator/generator.py`: `"=I"` → `">I"` in `_set_xrdcks_xattr`; update docstring table
- `tests/test_generator.py`: rename `test_adler32_value_stored_host_order` → `test_adler32_value_stored_big_endian`, fix read-back format; fix integration test read-back format

## Test plan

- [ ] `_set_xrdcks_xattr` unit tests pass (`TestSetXrdcksXattr`)
- [ ] `TestXattrIntegration::test_xattr_written_when_enabled` passes — stored value round-trips correctly
- [ ] `pytest tests/test_generator.py tests/test_rucio_client.py` — 131 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)